### PR TITLE
#22 相互フォロー同士のDM機能の実装

### DIFF
--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Conversations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Messages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,0 +1,22 @@
+class ConversationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @conversations = Conversation.all
+  end
+
+  def create
+    if Conversation.between(params[:sender_id], params[:recipient_id]).present?
+      @conversation = Conversation.between(params[:sender_id], params[:recipient_id]).first
+    else
+      @conversation = Conversation.create!(conversation_params)
+    end
+    redirect_to conversation_messages_path(@conversation)
+  end
+
+  private
+
+  def conversation_params
+    prams.permit(:sender_id, :recipient_id)
+  end
+end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -17,6 +17,6 @@ class ConversationsController < ApplicationController
   private
 
   def conversation_params
-    prams.permit(:sender_id, :recipient_id)
+    params.permit(:sender_id, :recipient_id)
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,37 @@
+class MessagesController < ApplicationController
+  before_action do
+    @conversation = Conversation.find(params[:conversation_id])
+  end
+
+  def index
+    @messages = @conversation.messages
+    if @messages.length > 10
+      @over_ten = true
+      @messages = Message.where(id: @messages[-10..-1].pluck(:id))
+    end
+    if params[:m]
+      @over_ten = false
+      @messages = @conversation.messages
+    end
+    if @messages.last
+      @messages.where.not(user_id: current_user.id).update_all(read: true)
+    end
+    @messages = @messages.order(:created_at)
+    @message = @conversation.messages.build
+  end
+
+  def create
+    @message = @conversation.messages.build(message_params)
+    if @message.save
+      redirect_to conversation_messages_path(@conversation)
+    else
+      render 'index'
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:body, :user_id)
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,9 +1,11 @@
 class MessagesController < ApplicationController
+  before_action :authenticate_user!
   before_action do
     @conversation = Conversation.find(params[:conversation_id])
   end
 
   def index
+    @users = User.all
     @messages = @conversation.messages
     if @messages.length > 10
       @over_ten = true

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,13 +2,14 @@ class UsersController < ApplicationController
 before_action :authenticate_user!, only: %i[index follow_index]
 
   def index
-    @users = User.all
+    @users = current_user.followings && current_user.followers if user_signed_in?
   end
 
   def follow_index
     @user = User.find(params[:id])
     @following_users = @user.followings
     @follower_users = @user.followers
+    @users = current_user.followings && current_user.followers if user_signed_in?
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,9 @@
 class UsersController < ApplicationController
+before_action :authenticate_user!, only: %i[index follow_index]
+
+  def index
+    @users = User.all
+  end
 
   def follow_index
     @user = User.find(params[:id])

--- a/app/helpers/conversations_helper.rb
+++ b/app/helpers/conversations_helper.rb
@@ -1,0 +1,2 @@
+module ConversationsHelper
+end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,2 @@
+module MessagesHelper
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,17 @@
+class Conversation < ApplicationRecord
+  belongs_to :sender, foreign_key: :sender_id, class_name: 'User'
+  belongs_to :recipient, foreign_key: :recipient_id, class_name: 'User'
+  has_many :messages, dependent: :destroy
+  validates_uniqueness_of :sender_id, scope: :recipient_id
+  scope :between, -> (sender_id, recipient_id) do
+    where("(conversations.sender_id = ? AND conversations.recipient_id = ?) OR (conversations.sender_id = ? AND conversations.recipient_id = ?)", sender_id, recipient_id, recipient_id, sender_id)
+  end
+
+  def target_user(current_user)
+    if sender_id == current_user.id
+      User.find(recipient_id)
+    elsif recipient_id == current_user.id
+      User.find(sender_id)
+    end
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,9 @@
+class Message < ApplicationRecord
+  belongs_to :conversation
+  belongs_to :user
+  validates_presence_of :body, :conversation_id, :user_id
+
+  def message_time
+    created_at.strftime("%y/%m/%d at %k:%M")
+  end
+end

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,0 +1,14 @@
+<table class="table table-hover">
+  <thead>
+    <h2>メッセージ一覧</h2>
+  </thead>
+  <tbody>
+    <% @conversations.each do |conversation| %>
+      <td>
+        <% if conversation.target_user(current_user).present? %>
+          <%= link_to conversation.target_user(current_user).name, conversation_messages_path(conversation)%>
+        <% end %>
+      </td>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
       <%= link_to "トップページ", articles_path %>
       <%= link_to "マイページ", user_path(current_user.id) %>
       <%= link_to "ランキング", rank_articles_path %>
+      <%= link_to "メッセージ", users_path %>
       <%= link_to '記事新規投稿', new_article_path %>
     <% else %>
       <%= link_to "新規登録", new_user_registration_path %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,0 +1,34 @@
+<% if @over_ten %>
+  <%= link_to '以前のメッセージ', '?m=all' %>
+<% end %>
+
+<div class="ui segment">
+  <% @messages.each do |message| %>
+    <% if message.body.present? %>
+      <div class="item">
+        <div class="content">
+          <div class="header"><strong><%= message.user.name %></strong> <%= message.message_time %></div>
+          <div class="list">
+            <div class="item">
+              <i class="right triangle icon"></i>
+              <%= message.body %> /
+              <% if message.user == current_user %>
+                <%= message.read ? '既読' : '未読' %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<%= form_with(model: [@conversation, @message]) do |f| %>
+  <div class="field">
+    <%= f.text_area :body, class: "form-control" %>
+  </div>
+    <%= f.text_field :user_id, value: current_user.id, type: "hidden"  %>
+  <div>
+    <%= f.submit "メッセージを送る" %>
+  </div>
+<% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,3 +1,5 @@
+<h2><%= @users.find(@conversation.sender_id).name %>さんと<%= @users.find(@conversation.recipient_id).name %>さんのメッセージ</h2>
+
 <% if @over_ten %>
   <%= link_to '以前のメッセージ', '?m=all' %>
 <% end %>
@@ -19,6 +21,7 @@
           </div>
         </div>
       </div>
+      <br>
     <% end %>
   <% end %>
 </div>

--- a/app/views/users/follow_index.html.erb
+++ b/app/views/users/follow_index.html.erb
@@ -1,12 +1,13 @@
 <table>
   <tr>
     <th>名前</th>
+    <th>フォロー</th>
   </tr>
 
-  <p>フォロー一覧</p><br/>
+  <h2>フォロー一覧</h2>
   <% @following_users.each do |user| %>
   <tr>
-    <td><%= user.name %></td>
+    <td><%= link_to user.name, user %></td>
     <td><%= render 'follow_form', user: user %></td>
   </tr>
   <% end %>
@@ -16,12 +17,13 @@
 <table>
   <tr>
     <th>名前</th>
+    <th>フォロー</th>
   </tr>
 
-  <p>フォロワー一覧</p><br/>
+  <h2>フォロワー一覧</h2>
   <% @follower_users.each do |user| %>
   <tr>
-    <td><%= user.name %></td>
+    <td><%= link_to user.name, user %></td>
     <td><%= render 'follow_form', user: user %></td>
   </tr>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,12 +1,20 @@
 <h2>DM可能ユーザー一覧</h2>
+<table>
+  <tr>
+    <th>名前</th>
+    <th>メッセージ</th>
+    <th>フォロー</th>
+  </tr>
+
 <% @users.each do |user| %>
   <% if user.id != current_user.id %>
-    <li>
+    <tr>
       <div class="item">
-        <%= link_to user.name, user %>
-        <%= link_to 'メッセージ', conversations_path(sender_id: current_user.id, recipient_id: user.id), method: :post %>
+        <td><%= link_to user.name, user %></td>
+        <td><%= link_to 'メッセージ', conversations_path(sender_id: current_user.id, recipient_id: user.id), method: :post %></td>
+        <td><%= render 'follow_form', user: user %></td> 
       </div>
-    </li>
-    <li><%= render 'follow_form', user: user %></li> 
+    </tr>
   <% end %>
 <% end %>
+</table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,12 @@
+<h2>DM可能ユーザー一覧</h2>
+<% @users.each do |user| %>
+  <% if user.id != current_user.id %>
+    <li>
+      <div class="item">
+        <%= link_to user.name, user %>
+        <%= link_to 'メッセージ', conversations_path(sender_id: current_user.id, recipient_id: user.id), method: :post %>
+      </div>
+    </li>
+    <li><%= render 'follow_form', user: user %></li> 
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,7 @@ Rails.application.routes.draw do
   end
   resources :favorites, only: [:create, :destroy, :index]
   resources :relationships, only: [:create, :destroy]
+  resources :conversations do
+    resources :messages
+  end
 end

--- a/db/migrate/20220813142535_create_conversations.rb
+++ b/db/migrate/20220813142535_create_conversations.rb
@@ -1,0 +1,13 @@
+class CreateConversations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :conversations do |t|
+      t.integer :sender_id
+      t.integer :recipient_id
+
+      t.timestamps
+    end
+    add_index :conversations, :sender_id
+    add_index :conversations, :recipient_id
+    add_index :conversations, [:sender_id, :recipient_id], unique: true
+  end
+end

--- a/db/migrate/20220813145202_create_messages.rb
+++ b/db/migrate/20220813145202_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :body
+      t.references :conversation, foreign_key: true
+      t.references :user, foreign_key: true
+      t.boolean :read, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_13_014510) do
+ActiveRecord::Schema.define(version: 2022_08_13_145202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,16 @@ ActiveRecord::Schema.define(version: 2022_08_13_014510) do
     t.bigint "user_id"
     t.index ["article_id"], name: "index_comments_on_article_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "conversations", force: :cascade do |t|
+    t.integer "sender_id"
+    t.integer "recipient_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["recipient_id"], name: "index_conversations_on_recipient_id"
+    t.index ["sender_id", "recipient_id"], name: "index_conversations_on_sender_id_and_recipient_id", unique: true
+    t.index ["sender_id"], name: "index_conversations_on_sender_id"
   end
 
   create_table "favorites", force: :cascade do |t|
@@ -80,6 +90,17 @@ ActiveRecord::Schema.define(version: 2022_08_13_014510) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "messages", force: :cascade do |t|
+    t.string "body"
+    t.bigint "conversation_id"
+    t.bigint "user_id"
+    t.boolean "read", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["conversation_id"], name: "index_messages_on_conversation_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
   create_table "relationships", force: :cascade do |t|
     t.integer "following_id"
     t.integer "follower_id"
@@ -121,4 +142,6 @@ ActiveRecord::Schema.define(version: 2022_08_13_014510) do
   add_foreign_key "favorites", "users"
   add_foreign_key "likes", "articles"
   add_foreign_key "likes", "users"
+  add_foreign_key "messages", "conversations"
+  add_foreign_key "messages", "users"
 end

--- a/test/controllers/conversations_controller_test.rb
+++ b/test/controllers/conversations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ConversationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MessagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  sender_id: 1
+  recipient_id: 1
+
+two:
+  sender_id: 1
+  recipient_id: 1

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  body: MyString
+  conversation: one
+  user: one
+  read: false
+
+two:
+  body: MyString
+  conversation: two
+  user: two
+  read: false

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ConversationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
 ユーザ同士のDM機能の実装
 メッセージにユーザの名前を表示（できたら送信時間も）
 既読・未読の表示
 相互フォロー時にのみDM可能にする
 DM一覧ページと個別のDMページを実装
 相互フォロー一覧ページに相互フォロー者とDM可能表示
 ヘッダーからDM一覧ページにリンク
上記内容実装完了しました
[参考記事](https://qiita.com/__kotaro_/items/0d88dce341356193afeb)
[参考記事](https://qiita.com/bindingpry/items/6790c91f374acc25bea2)